### PR TITLE
Settings file to enable proper comment toggling

### DIFF
--- a/settings/rgbasm.cson
+++ b/settings/rgbasm.cson
@@ -1,0 +1,3 @@
+'.source.asm.rgbasm':
+  'editor':
+    'commentStart': ';'


### PR DESCRIPTION
Lets Atom know to use `;` instead of the default `/* */` when using the Toggle Comments command.